### PR TITLE
Fixed statement of point 5 was confusing.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,5 +18,8 @@ The ERD is pictured below - not all tables are shown, but many of the key fields
 2. Explore tables by selecting all columns from each table or using the in built review features for your client.
 3. Select one column from a table. Get film titles.
 4. Select one column from a table and alias it. Get unique list of film languages under the alias `language`. Note that we are not asking you to obtain the language per each film, but this is a good time to think about how you might get that information in the future.
-5. Using the `select` statements and reviewing how many records are returned, can you find out how many stores and staff does the company have? Can you return a list of employee first names only?
-6. Bonus: How many unique days did customers rent movies in this dataset?
+5.
+* 5.1 Find out how many stores does the company have?
+* 5.2 Find out how many employees staff does the company have? 
+* 5.3 Return a list of employee first names only?
+


### PR DESCRIPTION
The point's 5 statement was confusing and was split in three.
sections 5.1, 5.2 and 5.3 which are more explicit.

In adittion, section 6 has been dropped as the students hadn't been
exposed to functions `convert` and `date_format`.

The Gist with the solutions has been commented accordingly.